### PR TITLE
Fixing modulation mistake

### DIFF
--- a/digitalcommunication.py
+++ b/digitalcommunication.py
@@ -1,5 +1,5 @@
 class DigitalCommunication:
-    def amplitude_modulation(self, message_signal, carrier_signal):
+    def dsb_sc(self, message_signal, carrier_signal):
         time_message = list(message_signal.keys())
         time_carrier = list(carrier_signal.keys())
 

--- a/dsptoolkit.py
+++ b/dsptoolkit.py
@@ -107,3 +107,4 @@ class DspToolKit:
         :param func:
         :return:
         '''
+        pass

--- a/test.py
+++ b/test.py
@@ -14,7 +14,7 @@ dtk.plot(message, title='Message Signal', mode='stem')
 carrier = disc.sinusoidal(time, omega=10)
 dtk.plot(carrier, title='Carrier Signal', mode='stem')
 
-func = dc.amplitude_modulation(message, carrier)
+func = dc.dsb_sc(message, carrier)
 dtk.plot(func, title='Amplitude Modulated signal', mode='stem')
 
 dtk.show()


### PR DESCRIPTION
## Fixing the nomenclature
Previously the function amplitude_modulation was doing dsb_sc modulation and not true AM. Now it is named more aptly to justify its results